### PR TITLE
Peripheral matter: a quick and relatively error-free method for translating math to code.

### DIFF
--- a/dbn_upper_bound/julia/ABprime.ipynb
+++ b/dbn_upper_bound/julia/ABprime.ipynb
@@ -1,0 +1,240 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Effective Bounds: A' and B'\n",
+    "\n",
+    "LaTeX for the expressions below was automatically rendered by MathJax from the [PolyMath 15 test problem page](michaelnielsen.org/polymath1/index.php?title=Polymath15_test_problem) using a right-click to bring up a menu and choosing `Show math | as LaTeX commands`. It was then copied and pasted directly into the markdown source of this section. Presumably, this process is free of error.\n",
+    "\n",
+    "It occurred to me that while translating mathematical notation into executable code, it would be handy to have the math juxtaposed with the code in the same document--someting Jupyter notebooks enable. Writing first in a notebook and automatically converting from notebook to source code, which Jupyter can also do, thus seemed like an efficient and reasonably error-free process.\n",
+    "\n",
+    "The [test problem page](michaelnielsen.org/polymath1/index.php?title=Polymath15_test_problem) defines approximations $A'$ and $B'$ as follows.\n",
+    "\n",
+    "$$A' = \\frac{2}{8} \\pi^{-s/2} \\sqrt{2\\pi} \\exp( (\\frac{s+4}{2}-\\frac{1}{2}) \\log \\frac{s+4}{2} - \\frac{s+4}{2}) \\sum_{n=1}^N \\frac{\\exp(\\frac{t}{16} \\log^2 \\frac{s+4}{2\\pi n^2})}{n^s}$$\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$$B' = \\frac{2}{8} \\pi^{-(1-s)/2} \\sqrt{2\\pi} \\exp( (\\frac{5-s}{2}-\\frac{1}{2}) \\log \\frac{5-s}{2} - \\frac{5-s}{2}) \\sum_{n=1}^N \\frac{\\exp(\\frac{t}{16} \\log^2 \\frac{5-s}{2\\pi n^2})}{n^{1-s}}$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$$B_0'= \\frac{2}{8} \\pi^{-(1-s)/2} \\sqrt{2\\pi} \\exp( (\\frac{5-s}{2}-\\frac{1}{2}) \\log \\frac{5-s}{2} - \\frac{5-s}{2}) \\exp( \\frac{t}{16} \\log^2 \\frac{5-s}{2\\pi} )$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is easily seen from the mathematical notation that $B'(s) = A'(1-s),$ and that $B_0'$ is just $B'$ with $N=1.$ Thus it suffices to code only $A'$ in detail. \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "using DBNUpperBound\n",
+    "using DBNUpperBound.Asymptotics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First coding the summand for $A'$\n",
+    "\n",
+    "$$a_n(s) = \\frac{\\exp(\\frac{t}{16} \\log^2 \\frac{s+4}{2\\pi n^2})}{n^s}$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Aprime_a (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "function Aprime_a(t::T1, s::T2, n::Int) where {T1<:Real, T2<:Number}\n",
+    "    return bigexp((t/16)*log((s+4)/(2*π*n^2))^2 - s*log(n))\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(Bigexp will use multiprecision if single precision exponentiation yields 0 or $\\pm \\infty$.) \n",
+    "\n",
+    "Next, coding the multiplier of the $\\sum_1^N$:\n",
+    "$$\\mu(s) = \\frac{2}{8} \\pi^{-s/2} \\sqrt{2\\pi} \\exp( (\\frac{s+4}{2}-\\frac{1}{2}) \\log \\frac{s+4}{2} - \\frac{s+4}{2})$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Aprime_μ (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "function Aprime_μ(t::T1, s::T2) where {T1<:Real, T2<:Number}\n",
+    "    return (2/8)*π^(-s/2)*√(2*π)*bigexp(((s+4)/2 - 1/2)*log((s+4)/2)-(s+4)/2)\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now,\n",
+    "$$ A' = \\mu(s)\\sum_1^N a_n(s).$$\n",
+    "Hence,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Aprime (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "function Aprime(t::T1, s::T2, N::Int) where {T1<:Real, T2<:Number}\n",
+    "    asum = 0.0\n",
+    "    for n = 1:N\n",
+    "        asum += Aprime_a(t,s,n)\n",
+    "    end\n",
+    "    return Aprime_μ(t,s)*asum\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And since $B'(s) = A'(1-s)$ and $B0' = B'$ with $N=1$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "B0prime (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Bprime(t,s,N) = Aprime(t,1-s,N) # (This is legal function definition syntax in Julia)\n",
+    "B0prime(t,s) = Bprime(t,s,1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "Comparison with the trusted Python implementation, `Ht_AFE_ADJ_AB`, serves as a quick initial test of the above. (The Python code is just cut and pasted from a terminal. It will not run in this notebook.) \n",
+    "\n",
+    "```\n",
+    " >>> from mputility import *\n",
+    " >>> z = 1000.0 + .4j\n",
+    " >>> Ht_AFE_ADJ_AB(z,.4)\n",
+    " >>> mpc(real='-5.1648957514753166742418230131433e-168', imag='3.13510483982411360761979246139316e-167')\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "-5.16489575148183e-168 + 3.1351048398242333e-167im"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "z = 1000.0 + .4im\n",
+    "N = Nz(z)\n",
+    "t = .4\n",
+    "s = (1+im*z)/2\n",
+    "Aprime(t,s,N)+Bprime(t,s,N)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "At this point the notebook can be converted to a source code file using the `File|Download as|Julia(.jl)` menu. (Referring to the standard notebook UI, not the new [JupyterLab](https://channel9.msdn.com/Events/PyData/Seattle2017/BRK11).) A little manual editing will make the download suitable for inclusion in the `DBNUpperBound` package. (See [src/asymptotics/ABprime.jl](https://github.com/WilCrofter/DBNUpperBound.jl/blob/master/src/asymptotics/ABprime.jl).)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 0.6.1",
+   "language": "julia",
+   "name": "julia-0.6"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "0.6.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This notebook illustrates a peripheral but somewhat interesting matter --a quick and accurate method of converting mathematical notation as it appears in the PolyMath 15 wiki and blog pages to code. Specifically, the math (as LaTeX or image) is copied and pasted into a Jupyter notebook directly above code blocks for easy visual reference. The notebook is then automatically converted to a source code file.

There are similar methods, of course, such as emacs with split windows. This method did save time and errors for me, however, so I thought I'd share it. The notebook can be previewed [here](https://github.com/WilCrofter/dbn_upper_bound/blob/master/dbn_upper_bound/julia/ABprime.ipynb).     